### PR TITLE
Improve sanitizer_config file format

### DIFF
--- a/sanitized_dump/config.py
+++ b/sanitized_dump/config.py
@@ -1,9 +1,11 @@
 import os
+import sys
 from collections import defaultdict
 
 import yaml
 from django.conf import settings
 
+from .utils.compat import deunicode
 from .utils.models import get_db_tables_and_columns_of_model, get_models
 
 # TODO: Figure out a way to get the dir where manage.py is without BASE_DIR
@@ -101,5 +103,11 @@ class Configuration(object):
             self.config['strategy'][table] = dict.fromkeys(columns)
 
     def write_configuration_file(self, file_path=standard_file_path):
+        if sys.version_info[0] >= 3:
+            config_data = self.config
+        else:
+            # deunicode config to avoid serializing unicode objects
+            # into the yaml file.
+            config_data = deunicode(self.config)
         with open(file_path, "w") as config_file:
-            yaml.dump(self.config, config_file, default_flow_style=False)
+            yaml.dump(config_data, config_file, default_flow_style=False)

--- a/sanitized_dump/utils/compat.py
+++ b/sanitized_dump/utils/compat.py
@@ -4,3 +4,21 @@ if six.PY3:
     builtins_open = 'builtins.open'
 else:
     builtins_open = '__builtin__.open'
+
+
+def deunicode(item):
+    """ Convert unicode objects to str """
+    if item is None:
+        return None
+    if isinstance(item, str):
+        return item
+    if isinstance(item, six.text_type):
+        return item.encode('utf-8')
+    if isinstance(item, dict):
+        return {
+            deunicode(key): deunicode(value)
+            for (key, value) in item.items()
+        }
+    if isinstance(item, list):
+        return [deunicode(x) for x in item]
+    raise TypeError('Unhandled item type: {!r}'.format(item))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,6 +53,14 @@ class TestConfiguration(object):
             conf = Configuration(yaml.load(conf_file))
             assert conf.in_sync_with_models
 
+    @patch(builtins_open, new_callable=MockOpen)
+    def test_configuration_file_unicode_formatting(self, mocked_open):
+        config = Configuration.from_models()
+        config.write_configuration_file()
+        with open(Configuration().standard_file_path, 'r') as conf_file:
+            contents = conf_file.read()
+            assert '!!python/unicode' not in contents
+
     def test_empty_config_is_not_valid(self):
         Configuration({}).validate()
 


### PR DESCRIPTION
Avoid having "!!python/unicode" in serialized config file.