### PR TITLE
Exit check with an error code

### DIFF
--- a/sanitized_dump/management/commands/check_sanitizerconfig.py
+++ b/sanitized_dump/management/commands/check_sanitizerconfig.py
@@ -26,6 +26,6 @@ class Command(DBReadonlyCommand):
                     'conf_file': Configuration.standard_file_name,
                 }))
 
-        self.stderr.write('OUT OF SYNC: {} is not up to date with your models.'.format(
+        raise SystemExit('OUT OF SYNC: {} is not up to date with your models.'.format(
             Configuration.standard_file_name
         ))

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,3 +1,5 @@
+import pytest
+
 from django.core.management import call_command
 from mock import patch
 from mock_open import MockOpen
@@ -24,8 +26,9 @@ def test_check_sanitizerconfig(mocked_open):
     """
     output = StringIO()
     err = StringIO()
-    call_command('check_sanitizerconfig', stderr=err, stdout=output)
-    assert 'OUT OF SYNC' in err.getvalue()
+    with pytest.raises(SystemExit) as e:
+        call_command('check_sanitizerconfig', stderr=err, stdout=output)
+        assert 'OUT OF SYNC' in str(e)
     assert 'IN SYNC' not in output.getvalue()
 
     output = StringIO()


### PR DESCRIPTION
Exit the check_sanitizer_config management command with an actual error code if the config is not up to date, rather than just writing to stderr.