### PR TITLE
Allow empty database hostname

### DIFF
--- a/sanitized_dump/utils/db.py
+++ b/sanitized_dump/utils/db.py
@@ -38,7 +38,7 @@ class DatabaseUrlBuilder(object):
         self.database = database
 
     def to_string(self):
-        if not all([self.engine, self.database, self.host]):
+        if not all([self.engine, self.database]):
             raise ValueError("Database configuration not supported")
 
         has_login = (self.user or self.password)
@@ -68,7 +68,7 @@ class DatabaseUrlBuilder(object):
             "engine": engine,
             "user": django_database.get("USER"),
             "password": django_database.get("PASSWORD"),
-            "host": django_database.get("HOST", None) or "localhost",
+            "host": django_database.get("HOST") or "",
             "port": django_database.get("PORT"),
             "database": django_database.get("NAME"),
         }
@@ -78,6 +78,10 @@ class DatabaseUrlBuilder(object):
             options_path = options.get("read_default_file", None)
             if options_path:
                 kwargs.update(read_mysql_options_from_path(options_path))
+
+        if kwargs["port"] and not kwargs["host"]:
+            # Port doesn't make sense without a hostname
+            kwargs["host"] = "localhost"
 
         return cls(**kwargs)
 

--- a/tests/test_db_url.py
+++ b/tests/test_db_url.py
@@ -11,13 +11,15 @@ from sanitized_dump.utils.db import db_setting_to_db_string
     ("django.db.backends.mysql", "db", "user", "password", "host", "3307",
         "mysql://user:password@host:3307/db"),
     ("django.db.backends.mysql", "db", "user", "password", None, None,
-        "mysql://user:password@localhost/db"),
+        "mysql://user:password@/db"),
     ("django.db.backends.postgresql", "db", "user", "password", None, None,
-        "postgres://user:password@localhost/db"),
+        "postgres://user:password@/db"),
     ("django.db.backends.postgresql", "db", "user", "password", None, 1111,
         "postgres://user:password@localhost:1111/db"),
     ("django.contrib.gis.db.backends.postgis", "johannes", "hernekeitto", "viina", "teline", 1111,
         "postgis://hernekeitto:viina@teline:1111/johannes"),
+    ("django.db.backends.postgresql", "baredb", None, None, None, None,
+        "postgres:///baredb"),
 ])
 def test_db_url_generation(engine, name, user, password, host, port, expected):
     databases = {
@@ -38,7 +40,7 @@ def test_db_url_generation(engine, name, user, password, host, port, expected):
 @pytest.mark.parametrize("database, user, password, host, port, expected", [
     ("db", "user", "password", "host", 3306, "mysql://user:password@host:3306/db"),
     ("db", "user", "password", "host", 3307, "mysql://user:password@host:3307/db"),
-    ("db", "user", "password", None, None, "mysql://user:password@localhost/db"),
+    ("db", "user", "password", None, None, "mysql://user:password@/db"),
     ("db", "user", "password", None, 5432, "mysql://user:password@localhost:5432/db"),
     ("db", "user", "password", None, 1111, "mysql://user:password@localhost:1111/db"),
     ("johannes", "hernekeitto", "viina", "teline", 1111, "mysql://hernekeitto:viina@teline:1111/johannes"),


### PR DESCRIPTION
Database URLs like postgres:///dbname are perfectly fine and should be
supported.  Make it possible to generate such database URLs without a
hostname and amend the tests.