### PR TITLE
Use yaml.safe_load instead of yaml.load

### DIFF
--- a/sanitized_dump/config.py
+++ b/sanitized_dump/config.py
@@ -35,7 +35,7 @@ class Configuration(object):
 
     @classmethod
     def from_file(cls, file):
-        conf = Configuration(yaml.load(file))
+        conf = Configuration(yaml.safe_load(file))
         conf.validate()
         return conf
 


### PR DESCRIPTION
Hello! Thanks for making this great library. I tried to use it today and came across this deprecation with my newer version of PyYAML. I just used a workaround in this PR (`save_load()`) but perhaps the requirements file(s) should be updated to a newer version of PyYAML? Either way, this resolved the error for me. Let me know if this is helpful!